### PR TITLE
Fix compilation with recent versions of Boost and miniupnpc

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1636,8 +1636,11 @@ static void ThreadMapPort()
     struct UPNPUrls urls;
     struct IGDdatas data;
     int r;
-
+#if (MINIUPNPC_API_VERSION >= 18)
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#else
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#endif
     if (r == 1)
     {
         if (fDiscover) {

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -626,8 +626,12 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
                         LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
                         return false;
                     }
-
+// copy_option was deprecated on boost 1.74
+#if BOOST_VERSION >= 107400
+                    fs::copy_file(pathSrc, pathDest, fs::copy_options::overwrite_existing);
+#else
                     fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
+#endif
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -58,7 +58,12 @@ std::vector<fs::path> ListWalletDir()
                 (ExistsBerkeleyDatabase(it->path()) || ExistsSQLiteDatabase(it->path()))) {
                 // Found a directory which contains wallet.dat btree file, add it as a wallet.
                 paths.emplace_back(path);
+// level was deprecated on boost 1.72
+#if BOOST_VERSION >= 107200
+            } else if (it.depth() == 0 && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
+#else
             } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && ExistsBerkeleyDatabase(it->path())) {
+#endif
                 if (it->path().filename() == "wallet.dat") {
                     // Found top-level wallet.dat btree file, add top level directory ""
                     // as a wallet.
@@ -73,7 +78,12 @@ std::vector<fs::path> ListWalletDir()
             }
         } catch (const std::exception& e) {
             LogPrintf("%s: Error scanning %s: %s\n", __func__, it->path().string(), e.what());
+// no_push was deprecated on boost 1.72
+#if BOOST_VERSION >= 107200
+            it.disable_recursion_pending();
+#else
             it.no_push();
+#endif
         }
     }
 


### PR DESCRIPTION
While compiling natively on Mac, `brew` installed recent versions of Boost and miniupnpc and the compilation failed since they changed the API a bit.

This PR makes the code compatible with both the recent and older versions.